### PR TITLE
fix: fix selectSpectraVariables with a single variable in localData

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: MsBackendMassbank
 Title: Mass Spectrometry Data Backend for MassBank record Files
-Version: 0.99.3
+Version: 0.99.4
 Authors@R:
     c(person(given = "RforMassSpectrometry Package Maintainer",
              email = "maintainer@rformassspectrometry.org",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # MsBackendMassbank 0.99
 
+## Changes in 0.99.4
+
+- Fix an issue in which `selectSpectraVariables,MsBackendMassbankSql` would fail
+  if subsetted to a single variable/column in `@localData` [issue
+  #29](https://github.com/rformassspectrometry/MsBackendMassbank/issues/29)
+
 ## Changes in 0.99.3
 
 - Drop names on the `peaksData`.

--- a/R/MsBackendMassbankSql.R
+++ b/R/MsBackendMassbankSql.R
@@ -752,7 +752,7 @@ setMethod(
         object@coreSpectraVariables <- intersect(object@coreSpectraVariables,
                                                  spectraVariables)
         object@localData <- object@localData[, colnames(object@localData) %in%
-                                               spectraVariables]
+                                               spectraVariables, drop = FALSE]
         validObject(object)
         object
     })

--- a/tests/testthat/test_MsBackendMassbankSql.R
+++ b/tests/testthat/test_MsBackendMassbankSql.R
@@ -180,6 +180,8 @@ test_that("selectSpectraVariables,MsBackendMassbankSql works", {
     res$new_col <- "b"
     expect_equal(spectraVariables(res),
                  c("rtime", "mz", "intensity", "new_col", "authors"))
+    res_2 <- selectSpectraVariables(res, spectraVariables(res))
+    expect_equal(spectraVariables(res), spectraVariables(res_2))
     res <- selectSpectraVariables(res, c("rtime"))
     expect_equal(spectraVariables(res), "rtime")
 })


### PR DESCRIPTION
- Fix `selectSpectraVariables,MsBackendMassbankSql` if `@localData` contains
  only a single column (issue #29).